### PR TITLE
use `build` instead of `pep517` in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install pep517 and twine
-        run: pip install pep517 twine
+      - name: Install build and twine
+        run: pip install build twine
 
       - name: Build source and binary
-        run: python -m pep517.build --source --binary .
+        run: python -m build --sdist --wheel .
 
       - name: Upload to PyPI
         env:


### PR DESCRIPTION
`pep517` is deprecated in favor of `build`: https://github.com/pypa/pep517#deprecated-high-level