### PR TITLE
make dtype testing more concise

### DIFF
--- a/tests/assets/test_dtype.py
+++ b/tests/assets/test_dtype.py
@@ -4,20 +4,17 @@ import torch
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
-    onlyCPU,
 )
 from torch.testing._internal.common_utils import TestCase
 
 
 class TestFoo(TestCase):
-    @onlyCPU
     @dtypes(torch.float16, torch.int32)
     # fails for float16, passes for int32
     def test_bar(self, device, dtype):
         assert dtype == torch.int32
 
     # passes for float16, skips for int32
-    @onlyCPU
     @dtypes(torch.float16, torch.int32)
     def test_baz(self, device, dtype):
         if dtype == torch.int32:
@@ -26,18 +23,16 @@ class TestFoo(TestCase):
         assert True
 
 
-instantiate_device_type_tests(TestFoo, globals())
+instantiate_device_type_tests(TestFoo, globals(), only_for="cpu")
 
 
 class TestSpam(TestCase):
-    @onlyCPU
     def test_ham(self, device):
         assert True
 
-    @onlyCPU
     @dtypes(torch.float16)
     def test_eggs(self, device, dtype):
         assert False
 
 
-instantiate_device_type_tests(TestSpam, globals())
+instantiate_device_type_tests(TestSpam, globals(), only_for="cpu")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -97,7 +97,7 @@ def test_device(testdir, file, cmds, outcomes):
         new_cmds=(),
         legacy_cmds=(),
         passed=3,
-        skipped=7,
+        skipped=1,
         failed=2,
     ),
     Config(
@@ -105,15 +105,15 @@ def test_device(testdir, file, cmds, outcomes):
         new_cmds="::TestFoo",
         legacy_cmds=("-k", "TestFoo"),
         passed=2,
-        skipped=5,
+        skipped=1,
         failed=1,
     ),
     Config(
-        "1testcase2-*test-*device",
+        "1testcase2-*test-*dtype",
         new_cmds="::TestSpam",
         legacy_cmds=("-k", "TestSpam"),
         passed=1,
-        skipped=2,
+        # skipped=2,
         failed=1,
     ),
     Config(
@@ -121,7 +121,6 @@ def test_device(testdir, file, cmds, outcomes):
         new_cmds=("-k", "float16"),
         legacy_cmds=("-k", "float16"),
         passed=1,
-        skipped=3,
         failed=2,
     ),
     Config(
@@ -129,7 +128,7 @@ def test_device(testdir, file, cmds, outcomes):
         new_cmds=("-k", "int32"),
         legacy_cmds=("-k", "int32"),
         passed=1,
-        skipped=3,
+        skipped=1,
     ),
     Config(
         "1testcase-*test-1dtype1",
@@ -137,21 +136,19 @@ def test_device(testdir, file, cmds, outcomes):
         legacy_cmds=("-k", "TestFoo and float16"),
         passed=1,
         failed=1,
-        skipped=2,
     ),
     Config(
         "1testcase-*test-1dtype2",
         new_cmds=("::TestFoo", "-k", "int32"),
         legacy_cmds=("-k", "TestFoo and int32"),
         passed=1,
-        skipped=3,
+        skipped=1,
     ),
     Config(
         "1testcase-1test1-*dtype",
         new_cmds="::TestFoo::test_bar",
         legacy_cmds=("-k", "TestFoo and test_bar"),
         passed=1,
-        skipped=2,
         failed=1,
     ),
     Config(
@@ -159,13 +156,12 @@ def test_device(testdir, file, cmds, outcomes):
         new_cmds="::TestFoo::test_baz",
         legacy_cmds=("-k", "TestFoo and test_baz"),
         passed=1,
-        skipped=3,
+        skipped=1,
     ),
     Config(
         "1testcase-1test-1dtype1",
         new_cmds=("::TestFoo::test_bar", "-k", "float16"),
         legacy_cmds=("-k", "TestFoo and test_bar and float16"),
-        skipped=1,
         failed=1,
     ),
     Config(
@@ -173,7 +169,6 @@ def test_device(testdir, file, cmds, outcomes):
         new_cmds=("::TestFoo::test_bar", "-k", "int32"),
         legacy_cmds=("-k", "TestFoo and test_bar and int32"),
         passed=1,
-        skipped=1,
     ),
 )
 def test_dtype(testdir, file, cmds, outcomes):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -113,7 +113,6 @@ def test_device(testdir, file, cmds, outcomes):
         new_cmds="::TestSpam",
         legacy_cmds=("-k", "TestSpam"),
         passed=1,
-        # skipped=2,
         failed=1,
     ),
     Config(


### PR DESCRIPTION
Instead of instantiating the tests for all devices and use the `@onlyCPU` decorator everywhere, used the `only_for` keyword when instantiating. With that the meta tests are not generated in the first place and do not need to be considered for the number of skipped tests.