### PR TITLE
refactor test suite to test the actual collection

### DIFF
--- a/tests/assets/_spy.py
+++ b/tests/assets/_spy.py
@@ -1,0 +1,97 @@
+from typing import Collection, Set, Tuple
+
+from torch.testing._internal.common_utils import TestCase as PyTorchTestCase
+
+
+class TestCase:
+    def __init__(
+        self,
+        template_test_case: PyTorchTestCase,
+        instantiated_test_cases: Collection[PyTorchTestCase],
+    ):
+        self.template_test_case_name = template_test_case.__name__
+
+        functions = []
+        for template_function_name in dir(template_test_case):
+            if not template_function_name.startswith("test_"):
+                continue
+
+            instantiated_test_cases_with_functions_names = [
+                (test_case.__name__, function_name)
+                for test_case in instantiated_test_cases
+                for function_name in dir(test_case)
+                if function_name.startswith(template_function_name)
+            ]
+
+            functions.append(
+                TestCaseFunction(
+                    template_test_case_name=self.template_test_case_name,
+                    template_function_name=template_function_name,
+                    instantiated_test_cases_with_functions_names=instantiated_test_cases_with_functions_names,
+                )
+            )
+        self.functions = functions
+
+    @property
+    def new_cmds(self) -> str:
+        return f"::{self.template_test_case_name}"
+
+    @property
+    def legacy_cmds(self) -> Tuple[str, ...]:
+        return ("-k", f"{self.template_test_case_name}")
+
+    def collect(self) -> Set[str]:
+        collection = set()
+        for function in self.functions:
+            collection.update(function.collect())
+        return collection
+
+
+class TestCaseFunction:
+    def __init__(
+        self,
+        *,
+        template_test_case_name: str,
+        template_function_name: str,
+        instantiated_test_cases_with_functions_names: Collection[Tuple[str, str]],
+    ) -> None:
+        self._template_test_case_name = template_test_case_name
+        self._template_function_name = template_function_name
+        self._instantiated_test_cases_with_functions_names = (
+            instantiated_test_cases_with_functions_names
+        )
+
+    @property
+    def new_cmds(self) -> str:
+        return f"::{self._template_test_case_name}::{self._template_function_name}"
+
+    @property
+    def legacy_cmds(self) -> Tuple[str, ...]:
+        return (
+            "-k",
+            f"{self._template_test_case_name} and {self._template_function_name}",
+        )
+
+    def collect(self) -> Set[str]:
+        return {
+            f"::{test_case_name}::{function_name}"
+            for test_case_name, function_name in self._instantiated_test_cases_with_functions_names
+        }
+
+
+class Spy:
+    def __init__(self):
+        self.test_cases = []
+
+    def __call__(self, instantiate_device_type_tests):
+        def wrapper(template_test_case, globals, *args, **kwargs):
+            before = set(globals.keys())
+            instantiate_device_type_tests(template_test_case, globals, *args, **kwargs)
+            after = set(globals.keys())
+            instantiated_test_cases = [globals[name] for name in (after - before)]
+
+            self.test_cases.append(
+                TestCase(template_test_case, instantiated_test_cases)
+            )
+
+        return wrapper

--- a/tests/assets/test_device.py
+++ b/tests/assets/test_device.py
@@ -5,30 +5,50 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_utils import TestCase
 
+# ======================================================================================
+# This block is necessary to autogenerate the parametrization for
+# tests/test_plugin.py::test_standard_collection.
+# It needs to be placed **after** the import of 'instantiate_device_type_tests' and
+# **before** its first usage.
+# ======================================================================================
+try:
+    from _spy import Spy
+
+    __spy__ = Spy()
+    del Spy
+    instantiate_device_type_tests = __spy__(instantiate_device_type_tests)
+except ModuleNotFoundError:
+    pass
+# ======================================================================================
+
 
 class TestFoo(TestCase):
-    # fails for meta, passes for cpu
     def test_bar(self, device):
-        assert device != "meta"
+        pass
 
-    # passes for meta, skips for cpu
-    @onlyOn("meta")
     def test_baz(self, device):
-        assert True
+        pass
 
 
-instantiate_device_type_tests(TestFoo, globals())
+instantiate_device_type_tests(TestFoo, globals(), only_for=["cpu", "meta"])
 
 
 class TestSpam(TestCase):
-    # passes for meta, fails for cpu
+    @onlyOn("meta")
     def test_ham(self, device):
-        assert device == "meta"
+        pass
 
-    # skips for meta, fails for cpu
     @onlyCPU
     def test_eggs(self, device):
-        assert False
+        pass
 
 
-instantiate_device_type_tests(TestSpam, globals())
+instantiate_device_type_tests(TestSpam, globals(), only_for=["cpu", "meta"])
+
+
+class TestQux(TestCase):
+    def test_quux(self, device):
+        pass
+
+
+instantiate_device_type_tests(TestQux, globals(), only_for=["cpu"])

--- a/tests/assets/test_dtype.py
+++ b/tests/assets/test_dtype.py
@@ -1,5 +1,3 @@
-import unittest
-
 import torch
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -7,32 +5,27 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_utils import TestCase
 
+# ======================================================================================
+# This block is necessary to autogenerate the parametrization for
+# tests/test_plugin.py::test_standard_collection.
+# It needs to be placed **after** the import of 'instantiate_device_type_tests' and
+# **before** its first usage.
+# ======================================================================================
+try:
+    from _spy import Spy
+
+    __spy__ = Spy()
+    del Spy
+    instantiate_device_type_tests = __spy__(instantiate_device_type_tests)
+except ModuleNotFoundError:
+    pass
+# ======================================================================================
+
 
 class TestFoo(TestCase):
     @dtypes(torch.float16, torch.int32)
-    # fails for float16, passes for int32
     def test_bar(self, device, dtype):
-        assert dtype == torch.int32
-
-    # passes for float16, skips for int32
-    @dtypes(torch.float16, torch.int32)
-    def test_baz(self, device, dtype):
-        if dtype == torch.int32:
-            raise unittest.SkipTest
-
-        assert True
+        pass
 
 
 instantiate_device_type_tests(TestFoo, globals(), only_for="cpu")
-
-
-class TestSpam(TestCase):
-    def test_ham(self, device):
-        assert True
-
-    @dtypes(torch.float16)
-    def test_eggs(self, device, dtype):
-        assert False
-
-
-instantiate_device_type_tests(TestSpam, globals(), only_for="cpu")

--- a/tests/assets/test_nested_names.py
+++ b/tests/assets/test_nested_names.py
@@ -1,24 +1,19 @@
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyOn,
-)
 from torch.testing._internal.common_utils import TestCase
 
 
 class TestFoo(TestCase):
-    # fails for meta, passes for cpu
-    def test_baz(self, device):
-        assert device != "meta"
-
-
-instantiate_device_type_tests(TestFoo, globals())
+    def test_baz(self):
+        pass
 
 
 class TestFooBar(TestCase):
-    # passes for meta, skips for cpu
-    @onlyOn("meta")
-    def test_baz(self, device):
-        assert True
+    def test_baz(self):
+        pass
 
 
-instantiate_device_type_tests(TestFooBar, globals())
+class TestSpam(TestCase):
+    def test_ham(self):
+        pass
+
+    def test_ham_eggs(self):
+        pass

--- a/tests/assets/test_op_infos.py
+++ b/tests/assets/test_op_infos.py
@@ -7,12 +7,28 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import OpInfo
 from torch.testing._internal.common_utils import TestCase
 
+# ======================================================================================
+# This block is necessary to autogenerate the parametrization for
+# tests/test_plugin.py::test_standard_collection.
+# It needs to be placed **after** the import of 'instantiate_device_type_tests' and
+# **before** its first usage.
+# ======================================================================================
+try:
+    from _spy import Spy
+
+    __spy__ = Spy()
+    del Spy
+    instantiate_device_type_tests = __spy__(instantiate_device_type_tests)
+except ModuleNotFoundError:
+    pass
+# ======================================================================================
+
 
 class TestFoo(TestCase):
     @dtypes(torch.float16, torch.int32)
     @ops([OpInfo("add"), OpInfo("sub")])
     def test_bar(self, device, dtype, op):
-        assert True
+        pass
 
 
-instantiate_device_type_tests(TestFoo, globals())
+instantiate_device_type_tests(TestFoo, globals(), only_for="cpu")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,22 @@
+import pytest
+
 pytest_plugins = ["pytester"]
+
+
+@pytest.fixture
+def collect_tests(testdir):
+    def collect_tests_(file: str, cmds: str):
+        testdir.copy_example(file)
+        result = testdir.runpytest("--quiet", "--collect-only", *cmds)
+        assert result.ret == pytest.ExitCode.OK
+
+        collection = set()
+        for line in result.outlines:
+            if not line:
+                break
+
+            collection.add(line)
+
+        return collection
+
+    return collect_tests_

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,4 @@
 import importlib
-import importlib.util
 import pathlib
 import sys
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,234 +1,111 @@
-from .utils import Config, make_params
+import importlib
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+from .utils import Config, make_parametrization, make_params
 
 
-@make_params(
-    "test_device.py",
-    Config(
-        "*testcase-*test-*device",
-        new_cmds=(),
-        legacy_cmds=(),
-        passed=3,
-        skipped=2,
-        failed=3,
-    ),
-    Config(
-        "1testcase1-*test-*device",
-        new_cmds="::TestFoo",
-        legacy_cmds=("-k", "TestFoo"),
-        passed=2,
-        skipped=1,
-        failed=1,
-    ),
-    Config(
-        "1testcase2-*test-*device",
-        new_cmds="::TestSpam",
-        legacy_cmds=("-k", "TestSpam"),
-        passed=1,
-        skipped=1,
-        failed=2,
-    ),
-    Config(
-        "*testcase-*test-1device1",
-        new_cmds=("-k", "meta"),
-        legacy_cmds=("-k", "META"),
-        passed=2,
-        skipped=1,
-        failed=1,
-    ),
-    Config(
-        "*testcase-*test-1device2",
-        new_cmds=("-k", "cpu"),
-        legacy_cmds=("-k", "CPU"),
-        passed=1,
-        skipped=1,
-        failed=2,
-    ),
-    Config(
-        "1testcase-*test-1device1",
-        new_cmds=("::TestFoo", "-k", "meta"),
-        legacy_cmds="::TestFooMETA",
-        passed=1,
-        failed=1,
-    ),
-    Config(
-        "1testcase-*test-1device2",
-        new_cmds=("::TestFoo", "-k", "cpu"),
-        legacy_cmds="::TestFooCPU",
-        passed=1,
-        skipped=1,
-    ),
-    Config(
-        "1testcase-1test1-*device",
-        new_cmds="::TestFoo::test_bar",
-        legacy_cmds=("-k", "TestFoo and test_bar"),
-        passed=1,
-        failed=1,
-    ),
-    Config(
-        "1testcase-1test2-*device",
-        new_cmds="::TestFoo::test_baz",
-        legacy_cmds=("-k", "TestFoo and test_baz"),
-        passed=1,
-        skipped=1,
-    ),
-    Config(
-        "1testcase-1test-1device1",
-        new_cmds=("::TestFoo::test_bar", "-k", "meta"),
-        legacy_cmds="::TestFooMETA::test_bar_meta",
-        failed=1,
-    ),
-    Config(
-        "1testcase-1test-1device2",
-        new_cmds=("::TestFoo::test_bar", "-k", "cpu"),
-        legacy_cmds="::TestFooCPU::test_bar_cpu",
-        passed=1,
-    ),
-)
-def test_device(testdir, file, cmds, outcomes):
-    testdir.copy_example(file)
-    result = testdir.runpytest(*cmds)
-    result.assert_outcomes(**outcomes)
+def make_standard_collection_parametrization():
+    def make_file_config(test_cases):
+        selection = set()
+        for test_case in test_cases:
+            selection.update(test_case.collect())
+        return Config(
+            selection=selection,
+        )
+
+    def make_test_case_configs(test_cases):
+        return [
+            Config(
+                new_cmds=test_case.new_cmds,
+                legacy_cmds=test_case.legacy_cmds,
+                selection=test_case.collect(),
+            )
+            for test_case in test_cases
+        ]
+
+    def make_test_case_functions_configs(test_cases):
+        return [
+            Config(
+                new_cmds=test_case_function.new_cmds,
+                legacy_cmds=test_case_function.legacy_cmds,
+                selection=test_case_function.collect(),
+            )
+            for test_case in test_cases
+            for test_case_function in test_case.functions
+        ]
+
+    params = []
+    assets = pathlib.Path(__file__).parent / "assets"
+    sys.path.insert(0, str(assets))
+    modules = sys.modules.copy()
+    try:
+        for test_file in assets.iterdir():
+            module = test_file.stem
+            if not test_file.name.startswith("test"):
+                continue
+
+            try:
+                test_module = importlib.import_module(module)
+                spy = test_module.__spy__
+            except Exception:
+                continue
+
+            params.extend(
+                make_params(
+                    make_file_config(spy.test_cases),
+                    *make_test_case_configs(spy.test_cases),
+                    *make_test_case_functions_configs(spy.test_cases),
+                    file=test_file.name,
+                )
+            )
+    finally:
+        sys.path.remove(str(assets))
+        sys.modules = modules
+
+    return pytest.mark.parametrize(Config.PARAM_NAMES, params)
 
 
-@make_params(
-    "test_dtype.py",
-    Config(
-        "*test-*device-*dtype",
-        new_cmds=(),
-        legacy_cmds=(),
-        passed=3,
-        skipped=1,
-        failed=2,
-    ),
-    Config(
-        "1testcase1-*test-*dtype",
-        new_cmds="::TestFoo",
-        legacy_cmds=("-k", "TestFoo"),
-        passed=2,
-        skipped=1,
-        failed=1,
-    ),
-    Config(
-        "1testcase2-*test-*dtype",
-        new_cmds="::TestSpam",
-        legacy_cmds=("-k", "TestSpam"),
-        passed=1,
-        failed=1,
-    ),
-    Config(
-        "*testcase-*test-1dtype1",
-        new_cmds=("-k", "float16"),
-        legacy_cmds=("-k", "float16"),
-        passed=1,
-        failed=2,
-    ),
-    Config(
-        "*testcase-*test-1dtype2",
-        new_cmds=("-k", "int32"),
-        legacy_cmds=("-k", "int32"),
-        passed=1,
-        skipped=1,
-    ),
-    Config(
-        "1testcase-*test-1dtype1",
-        new_cmds=("::TestFoo", "-k", "float16"),
-        legacy_cmds=("-k", "TestFoo and float16"),
-        passed=1,
-        failed=1,
-    ),
-    Config(
-        "1testcase-*test-1dtype2",
-        new_cmds=("::TestFoo", "-k", "int32"),
-        legacy_cmds=("-k", "TestFoo and int32"),
-        passed=1,
-        skipped=1,
-    ),
-    Config(
-        "1testcase-1test1-*dtype",
-        new_cmds="::TestFoo::test_bar",
-        legacy_cmds=("-k", "TestFoo and test_bar"),
-        passed=1,
-        failed=1,
-    ),
-    Config(
-        "1testcase-1test2-*dtype",
-        new_cmds="::TestFoo::test_baz",
-        legacy_cmds=("-k", "TestFoo and test_baz"),
-        passed=1,
-        skipped=1,
-    ),
-    Config(
-        "1testcase-1test-1dtype1",
-        new_cmds=("::TestFoo::test_bar", "-k", "float16"),
-        legacy_cmds=("-k", "TestFoo and test_bar and float16"),
-        failed=1,
-    ),
-    Config(
-        "1testcase-1test-1dtype2",
-        new_cmds=("::TestFoo::test_bar", "-k", "int32"),
-        legacy_cmds=("-k", "TestFoo and test_bar and int32"),
-        passed=1,
-    ),
-)
-def test_dtype(testdir, file, cmds, outcomes):
-    testdir.copy_example(file)
-    result = testdir.runpytest(*cmds)
-    result.assert_outcomes(**outcomes)
+@make_standard_collection_parametrization()
+def test_standard_collection(collect_tests, file, cmds, selection):
+    collection = collect_tests(file, cmds)
+    assert collection == selection
 
 
-@make_params(
-    "test_nested_names.py",
+@make_parametrization(
     Config(
-        "*testcase-*test-*device",
-        new_cmds=(),
-        legacy_cmds=(),
-        passed=2,
-        skipped=1,
-        failed=1,
+        selection=(
+            "::TestFoo::test_baz",
+            "::TestFooBar::test_baz",
+            "::TestSpam::test_ham",
+            "::TestSpam::test_ham_eggs",
+        ),
     ),
     Config(
-        "1testcase1-*test-*device",
         new_cmds="::TestFoo",
         legacy_cmds=("-k", "TestFoo and not TestFooBar"),
-        passed=1,
-        failed=1,
+        selection=("::TestFoo::test_baz",),
     ),
     Config(
-        "1testcase2-*test-*device",
         new_cmds="::TestFooBar",
         legacy_cmds=("-k", "TestFooBar"),
-        passed=1,
-        skipped=1,
+        selection=("::TestFooBar::test_baz",),
     ),
+    Config(
+        new_cmds="::TestSpam::test_ham",
+        legacy_cmds=("-k", "TestSpam and test_ham and not test_ham_eggs"),
+        selection=("::TestSpam::test_ham",),
+    ),
+    Config(
+        new_cmds="::TestSpam::test_ham_eggs",
+        legacy_cmds=("-k", "TestSpam and test_ham_eggs"),
+        selection=("::TestSpam::test_ham_eggs",),
+    ),
+    file="test_nested_names.py",
 )
-def test_nested_names(testdir, file, cmds, outcomes):
-    testdir.copy_example(file)
-    result = testdir.runpytest(*cmds)
-    result.assert_outcomes(**outcomes)
-
-
-@make_params(
-    "test_op_infos.py",
-    Config(
-        "*testcase-*test-*op-*device-*dtype",
-        new_cmds=(),
-        legacy_cmds=(),
-        passed=8,
-    ),
-    Config(
-        "1testcase-*test-*op-*device-*dtype",
-        new_cmds="::TestFoo",
-        legacy_cmds=("-k", "TestFoo"),
-        passed=8,
-    ),
-    Config(
-        "1testcase-1test-*op-*device-*dtype",
-        new_cmds="::TestFoo::test_bar",
-        legacy_cmds=("-k", "TestFoo and test_bar"),
-        passed=8,
-    ),
-)
-def test_op_infos(testdir, file, cmds, outcomes):
-    testdir.copy_example(file)
-    result = testdir.runpytest(*cmds)
-    result.assert_outcomes(**outcomes)
+def test_nested_names(collect_tests, file, cmds, selection):
+    collection = collect_tests(file, cmds)
+    assert collection == selection


### PR DESCRIPTION
Before we tested the collection by using different outcomes for each test based on the respective parameter. Afterwards we checked the `pytest` result against that. This has two downsides:

1. It takes more mental effort to not only parse which test will run, but also how the outcome of all run tests is.
2. Since we could only test against the aggregated result for multiple tests, we can't be sure the test is actually right.

With this PR we are actually testing the collection, by parsing the `pytest` output. Additionally, you can now add this codeblock

```python
# ======================================================================================
# This block is necessary to autogenerate the parametrization for
# tests/test_plugin.py::test_standard_collection.
# It needs to be placed **after** the import of 'instantiate_device_type_tests' and
# **before** its first usage.
# ======================================================================================
try:
    from _spy import Spy

    __spy__ = Spy()
    del Spy
    instantiate_device_type_tests = __spy__(instantiate_device_type_tests)
except ModuleNotFoundError:
    pass
# ======================================================================================
```

to a test file to automatically test the selection of
- everything in the file,
- every test case, and
- every test case function.

Anything beyond that still needs to be configured manually.