### PR TITLE
trim the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,13 @@ jobs:
   integration:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
         python: ['3.6', '3.7', '3.8', '3.9']
-      fail-fast: true
+        include:
+          - os: windows-latest
+            python: "3.6"
+          - os: macos-latest
+            python: "3.6"
 
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
We don't need to test this for every os / python combination. It should be sufficient to test every os with the minimum python requirement as well as one (linux) with every supported python version.

This should speed up the CI runs and save some resources.