### PR TITLE
remove duplicate tests

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -77,7 +77,6 @@ def test_standard_collection(collect_tests, file, cmds, selection):
 @make_parametrization(
     Config(
         new_cmds=("-k", "cpu"),
-        legacy_cmds=("-k", "cpu"),
         selection=(
             "::TestFooCPU::test_bar_cpu",
             "::TestFooCPU::test_baz_cpu",
@@ -88,7 +87,6 @@ def test_standard_collection(collect_tests, file, cmds, selection):
     ),
     Config(
         new_cmds=("-k", "meta"),
-        legacy_cmds=("-k", "meta"),
         selection=(
             "::TestFooMETA::test_bar_meta",
             "::TestFooMETA::test_baz_meta",
@@ -106,7 +104,6 @@ def test_devices(collect_tests, file, cmds, selection):
 @make_parametrization(
     Config(
         new_cmds=("-k", "float16"),
-        legacy_cmds=("-k", "float16"),
         selection=(
             "::TestFooCPU::test_bar_cpu_float16",
             "::TestFooCPU::test_bar_cpu_float16",
@@ -114,7 +111,6 @@ def test_devices(collect_tests, file, cmds, selection):
     ),
     Config(
         new_cmds=("-k", "int32"),
-        legacy_cmds=("-k", "int32"),
         selection=(
             "::TestFooCPU::test_bar_cpu_int32",
             "::TestFooCPU::test_bar_cpu_int32",
@@ -130,7 +126,6 @@ def test_dtypes(collect_tests, file, cmds, selection):
 @make_parametrization(
     Config(
         new_cmds=("-k", "add"),
-        legacy_cmds=("-k", "add"),
         selection=(
             "::TestFooCPU::test_bar_add_cpu_float32",
             "::TestFooCPU::test_bar_add_with_alpha_cpu_float32",
@@ -138,7 +133,6 @@ def test_dtypes(collect_tests, file, cmds, selection):
     ),
     Config(
         new_cmds=("-k", "sub"),
-        legacy_cmds=("-k", "sub"),
         selection=(
             "::TestFooCPU::test_bar_sub_cpu_float32",
             "::TestFooCPU::test_bar_sub_with_alpha_cpu_float32",


### PR DESCRIPTION
In some cases `new_cmds == legacy_cmds`. This made it more verbose to write and additionally resulted in duplicate tests.

After this PR, if no `legacy_cmds` is passed to `Config`, the value of `new_cmds` is used. Plus, duplicate configs are filtered out.