### PR TITLE
Change test workflows from PyTorch nightly to stable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,18 +20,12 @@ commands = pre-commit run --all-files
 passenv =
   GITHUB_ACTIONS
 pytorch_force_cpu = True
-# We need the 'meta' device to be able to test with a second device apart from 'cpu'.
-# It was only added after the current release, so we test against the nightlies for
-# now.
-# TODO: Use a stable torch>1.8 when it is available.
-pytorch_channel = nightly
 deps =
   pytest >= 6
   pytest-mock >= 3.1
-  torch
-  # The nightlies do not specify numpy as requirement
+  torch >= 1.9
+  # PyTorch's test suite requires numpy and scipy, but they are no dependencies of torch
   numpy
-  # Importing OpInfo requires scipy unconditionally
   scipy
 commands =
   pytest -c pytest.ini {posargs}


### PR DESCRIPTION
Previously, we used PyTorch nightly to have a second device available in CI. As of `torch==1.9` the `"meta"` device is included in the stable binaries. Thus, there is no need for less safe nightly testing anymore.